### PR TITLE
Paddles bugfix

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -27,6 +27,7 @@
 #include "Switches.hxx"
 #include "MD5.hxx"
 #include "SoundSDL.hxx"
+#include "Paddles.hxx"
 
 struct					Stella
 {
@@ -174,6 +175,13 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 
 bool retro_load_game(const struct retro_game_info *info)
 {
+    /* This might not be the best place to call these. These two functions
+     * must be called before starting a game with paddles.
+     * The magic number 5 is "medium" paddle sensitivity (range 1-10)
+     */
+    Paddles::setDigitalSensitivity(5);
+    Paddles::setMouseSensitivity(5);
+
     stella = new Stella();
     const char *full_path;
     


### PR DESCRIPTION
Previously, attempting to launch a game that used Paddle controllers would fail because the assertion on the line https://github.com/mdraves91/stella-libretro/blob/bugfix-p2controller/stella/input/Paddles.cpp#L225 would fail since two of the Paddles global variables were never initialized.

This commit makes sure they are initialized when a game is loaded.

You should probably accept my other pull request first because this branch came out of the other bugfix branch (whoops)
