### PR TITLE
Report git version with library_version on Android

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,11 +1,12 @@
 LOCAL_PATH := $(call my-dir)
+
+CORE_DIR := ../stella
+include $(CLEAR_VARS)
+
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
-
-CORE_DIR := ../stella
-include $(CLEAR_VARS)
 
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DANDROID_ARM


### PR DESCRIPTION
This patch fixes GIT_VERSION on Android, which was missing due to bugs in Android.mk. Important for netplay between Android and non-Android systems.