### PR TITLE
Use STELLA_VERSION for version

### DIFF
--- a/libretro.cxx
+++ b/libretro.cxx
@@ -25,6 +25,7 @@
 #include "Paddles.hxx"
 #include "SoundSDL.hxx"
 #include "M6532.hxx"
+#include "Version.hxx"
 
 #include "Stubs.hxx"
 
@@ -103,7 +104,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
-   info->library_version = "3.9.3" GIT_VERSION;
+   info->library_version = STELLA_VERSION GIT_VERSION;
    info->need_fullpath = false;
    info->valid_extensions = "a26|bin";
 }


### PR DESCRIPTION
Small pull request that updates the version declared to the libretro API to use the one that's defined in Version.cxx. Saves us from having to update it manually.